### PR TITLE
Changed radiation potion functionalities

### DIFF
--- a/src/main/java/net/nuclearteam/createnuclear/CNItems.java
+++ b/src/main/java/net/nuclearteam/createnuclear/CNItems.java
@@ -12,9 +12,10 @@ import static net.nuclearteam.createnuclear.content.equipment.armor.AntiRadiatio
 
 import com.tterrag.registrate.util.entry.ItemEntry;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.TagKey;
+import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.Mob;
+import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.item.Item;
 import net.minecraftforge.common.ForgeSpawnEggItem;
 import net.nuclearteam.createnuclear.content.equipment.armor.AntiRadiationArmorItem;
@@ -28,8 +29,15 @@ import java.util.function.Supplier;
 public class CNItems {
 
     public static final ItemEntry<Item>
-        YELLOWCAKE = CreateNuclear.REGISTRATE
+            YELLOWCAKE = CreateNuclear.REGISTRATE
             .item("yellowcake", Item::new)
+            .properties(p -> p.food(new FoodProperties.Builder()
+                    .nutrition(20)
+                    .saturationMod(0.3F)
+                    .alwaysEat()
+                    .effect((new MobEffectInstance(CNEffects.RADIATION.get(),600,2)) , 1.0F)
+                    .build())
+            )
             .register(),
 
         RAW_LEAD = CreateNuclear.REGISTRATE


### PR DESCRIPTION
This pull request includes changes to the `CNItems.java` file to add food properties to the `YELLOWCAKE` item. The most important changes are:

Enhancements to `YELLOWCAKE` item:

* Added `FoodProperties` to the `YELLOWCAKE` item, including nutrition, saturation, always eat, and a radiation effect.

Imports update:

* Added imports for `MobEffectInstance` and `FoodProperties`.