### PR TITLE
Modified reinforced glass resistance

### DIFF
--- a/src/main/java/net/nuclearteam/createnuclear/CNBlocks.java
+++ b/src/main/java/net/nuclearteam/createnuclear/CNBlocks.java
@@ -169,7 +169,7 @@ public class CNBlocks {
     public static final BlockEntry<ReinforcedGlassBlock> REINFORCED_GLASS = CreateNuclear.REGISTRATE
             .block("reinforced_glass", ReinforcedGlassBlock::new)
             .initialProperties(() -> Blocks.GLASS)
-            .properties(p -> p.explosionResistance(1200F).destroyTime(2F))
+            .properties(p -> p.explosionResistance(7.0F).destroyTime(2F))
             .onRegister(CreateRegistrate.connectedTextures(() -> new EncasedCTBehaviour(CNSpriteShifts.REACTOR_GLASS)))
             .onRegister(casingConnectivity((block,cc) -> cc.makeCasing(block, CNSpriteShifts.REACTOR_GLASS)))
             .loot(RegistrateBlockLootTables::dropWhenSilkTouch)


### PR DESCRIPTION
This pull request includes a change to the explosion resistance property of the `REINFORCED_GLASS` block in the `CNBlocks` class. The most important change is:

* [`src/main/java/net/nuclearteam/createnuclear/CNBlocks.java`](diffhunk://#diff-2877134e50094bdb3830ab6f68d42eaf79c9f3b3f81a6ad22f912ce1dd157414L172-R172): Modified the explosion resistance of `REINFORCED_GLASS` from 1200F to 7.0F.