### PR TITLE
modifs

### DIFF
--- a/src/generated/resources/.cache/15812fa7bc190aa8f0a8644088c7ff563925e506
+++ b/src/generated/resources/.cache/15812fa7bc190aa8f0a8644088c7ff563925e506
@@ -1,4 +1,4 @@
-// 1.20.1	2025-03-07T23:26:05.6423041	CreateNuclear's Processing Recipes
+// 1.20.1	2025-03-19T11:40:04.4388497	CreateNuclear's Processing Recipes
 d02fe65c0c4f06b58fa7565d7254902de5018e8b data/createnuclear/advancements/recipes/building_blocks/shapeless/cloth/black_cloth.json
 9690e12858db1c546576ce70847e723c005f814e data/createnuclear/advancements/recipes/building_blocks/shapeless/cloth/blue_cloth.json
 3bebcd85a99be0ddec8db66c5734232ac4bbd2ad data/createnuclear/advancements/recipes/building_blocks/shapeless/cloth/brown_cloth.json
@@ -27,7 +27,9 @@ f0d205d168427e468bffe76d4400305528d701b5 data/createnuclear/recipes/compacting/u
 24c35af7a9dc3d740f3200bdd1ad96ad125df00a data/createnuclear/recipes/crushing/coal.json
 2a8b609dba5bad88511d9c9a80cf6fb582b18c36 data/createnuclear/recipes/crushing/fix/crushed_raw_uranium.json
 57154e35ebb09170bb39f5b3a72ecd49182697f2 data/createnuclear/recipes/crushing/granite.json
+4feb59d85e86e34ed565c18b6a4df120fe050bc7 data/createnuclear/recipes/crushing/raw_copper.json
 cf17713133d3e05e99164e2ea6649de3aef017fd data/createnuclear/recipes/crushing/raw_uranium_block.json
+26d2787e831b9986ed6f90f8ea803d5fdc544bf5 data/createnuclear/recipes/crushing/raw_zinc.json
 e42be7d17c5e057e62c4b1176cbf43319a157f51 data/createnuclear/recipes/enriched/enriched_yellowcake.json
 74555eb2cce0827f99dc5c4ff91362bdaecad725 data/createnuclear/recipes/enriched/enriching_campfire.json
 5cee3df3d7c7cd41d6a94a36b713dddc77f2acc4 data/createnuclear/recipes/item_application/reactor_casing_from_steel_and_brass_casing.json

--- a/src/generated/resources/.cache/fed443662143001aeb5341375f6f5ef31d10baea
+++ b/src/generated/resources/.cache/fed443662143001aeb5341375f6f5ef31d10baea
@@ -1,7 +1,7 @@
-// 1.20.1	2025-02-02T13:23:38.0123343	CreateNuclear Generated Registry Entries
+// 1.20.1	2025-03-19T11:40:04.4388497	CreateNuclear Generated Registry Entries
 5edbd74546f4088818e02bb7a5c5eb2ecfe25623 data/createnuclear/forge/biome_modifier/lead_ore.json
 fa32145101dc12ec914684fec8c5cbb995d2c051 data/createnuclear/forge/biome_modifier/uranium_ore.json
 b68555f371c9700aa4ecfa9370b010de8fe25b60 data/createnuclear/worldgen/configured_feature/lead_ore.json
 b0e1ee7314412507fd7346cb48b29d105f6186ad data/createnuclear/worldgen/configured_feature/uranium_ore.json
-ec82b14bb50728a37053e6dc6ce7832141651f49 data/createnuclear/worldgen/placed_feature/lead_ore.json
-06120ed6a00e684c347732b8178cef3bdf095ded data/createnuclear/worldgen/placed_feature/uranium_ore.json
+d45ed5f7008864ba4f60c409038ad428a280fd7f data/createnuclear/worldgen/placed_feature/lead_ore.json
+bed936158c61471513252910d9e3b0e2de610f1a data/createnuclear/worldgen/placed_feature/uranium_ore.json

--- a/src/generated/resources/data/createnuclear/recipes/crushing/raw_copper.json
+++ b/src/generated/resources/data/createnuclear/recipes/crushing/raw_copper.json
@@ -1,0 +1,22 @@
+{
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "minecraft:raw_copper"
+    }
+  ],
+  "processingTime": 250,
+  "results": [
+    {
+      "item": "create:crushed_raw_copper"
+    },
+    {
+      "chance": 0.75,
+      "item": "create:experience_nugget"
+    },
+    {
+      "chance": 0.15,
+      "item": "createnuclear:lead_nugget"
+    }
+  ]
+}

--- a/src/generated/resources/data/createnuclear/recipes/crushing/raw_zinc.json
+++ b/src/generated/resources/data/createnuclear/recipes/crushing/raw_zinc.json
@@ -1,0 +1,22 @@
+{
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "create:raw_zinc"
+    }
+  ],
+  "processingTime": 250,
+  "results": [
+    {
+      "item": "create:crushed_raw_zinc"
+    },
+    {
+      "chance": 0.75,
+      "item": "create:experience_nugget"
+    },
+    {
+      "chance": 0.25,
+      "item": "createnuclear:lead_nugget"
+    }
+  ]
+}

--- a/src/generated/resources/data/createnuclear/worldgen/placed_feature/lead_ore.json
+++ b/src/generated/resources/data/createnuclear/worldgen/placed_feature/lead_ore.json
@@ -11,7 +11,7 @@
     {
       "type": "minecraft:height_range",
       "height": {
-        "type": "minecraft:uniform",
+        "type": "minecraft:trapezoid",
         "max_inclusive": {
           "absolute": 64
         },

--- a/src/generated/resources/data/createnuclear/worldgen/placed_feature/uranium_ore.json
+++ b/src/generated/resources/data/createnuclear/worldgen/placed_feature/uranium_ore.json
@@ -11,7 +11,7 @@
     {
       "type": "minecraft:height_range",
       "height": {
-        "type": "minecraft:uniform",
+        "type": "minecraft:trapezoid",
         "max_inclusive": {
           "absolute": 64
         },

--- a/src/main/java/net/nuclearteam/createnuclear/content/effects/RadiationEffect.java
+++ b/src/main/java/net/nuclearteam/createnuclear/content/effects/RadiationEffect.java
@@ -6,10 +6,15 @@ import net.minecraft.world.entity.LivingEntity;
 import net.nuclearteam.createnuclear.CNEffects;
 import net.nuclearteam.createnuclear.CNTags;
 import net.nuclearteam.createnuclear.content.equipment.armor.AntiRadiationArmorItem;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 
 public class RadiationEffect extends MobEffect {
     public RadiationEffect() {
+
         super(MobEffectCategory.HARMFUL, 15453236);
+        this.addAttributeModifier(Attributes.ATTACK_DAMAGE, "648D7064-6A60-4F59-8ABE-C2C23A6DD7A9", -0.2D, AttributeModifier.Operation.MULTIPLY_TOTAL);
+        this.addAttributeModifier(Attributes.ATTACK_SPEED, "55FCED67-E92A-486E-9800-B47F202C4386", -0.2D, AttributeModifier.Operation.MULTIPLY_TOTAL);
     }
 
     @Override

--- a/src/main/java/net/nuclearteam/createnuclear/foundation/data/recipe/CNCrushingRecipeGen.java
+++ b/src/main/java/net/nuclearteam/createnuclear/foundation/data/recipe/CNCrushingRecipeGen.java
@@ -40,7 +40,38 @@ public class CNCrushingRecipeGen extends CNProcessingRecipeGen {
                 .output(1, CNItems.URANIUM_POWDER, 9)
         ),
         RAW_URANIUM_BLOCK = create(() -> CNBlocks.RAW_URANIUM_BLOCK, b -> b.duration(250)
-            .output(1, CNItems.URANIUM_POWDER,81))
+            .output(1, CNItems.URANIUM_POWDER,81)),
+
+        RAW_ZINC = create(() -> AllItems.RAW_ZINC, b -> b.duration(250)
+
+
+
+            .output(1, AllItems.CRUSHED_ZINC, 1)
+
+
+                .output(.75f, AllItems.EXP_NUGGET, 1)
+
+
+                .output(.25f, CNItems.LEAD_NUGGET,1)
+
+
+        ),
+
+
+    RAW_COPPER = create(() -> Items.RAW_COPPER, b -> b.duration(250)
+
+
+            .output(1, AllItems.CRUSHED_COPPER, 1)
+
+
+                .output(.75f, AllItems.EXP_NUGGET, 1)
+
+
+                .output(.15f, CNItems.LEAD_NUGGET,1)
+
+        )
+
+
     ;
 
     public CNCrushingRecipeGen(PackOutput generator) {

--- a/src/main/java/net/nuclearteam/createnuclear/infrastructure/worldgen/CNPlacedFeatures.java
+++ b/src/main/java/net/nuclearteam/createnuclear/infrastructure/worldgen/CNPlacedFeatures.java
@@ -38,7 +38,7 @@ public class CNPlacedFeatures {
         return List.of(
                 frequency,
                 InSquarePlacement.spread(),
-                HeightRangePlacement.uniform(VerticalAnchor.absolute(minHeight), VerticalAnchor.absolute(maxHeight)),
+                HeightRangePlacement.triangle(VerticalAnchor.absolute(minHeight), VerticalAnchor.absolute(maxHeight)),
                 ConfigPlacementFilter.INSTANCE
         );
     }


### PR DESCRIPTION
This pull request includes several important changes to the `CreateNuclear` project, focusing on enhancing the functionality of radiation effects, expanding recipe generation, and modifying world generation placement logic.

### Enhancements to Radiation Effects:

* [`src/main/java/net/nuclearteam/createnuclear/content/effects/RadiationEffect.java`](diffhunk://#diff-ec7bffa5b12aee8394bb127626fc48d05b14ff45115c96294e287328cc582931R9-R17): Added attribute modifiers to reduce attack damage and attack speed when the radiation effect is applied.

### Expansion of Recipe Generation:

* [`src/main/java/net/nuclearteam/createnuclear/foundation/data/recipe/CNCrushingRecipeGen.java`](diffhunk://#diff-f0013e324145cc37b25a38a2b918f684d70ecac1203f1a7a4fb93a2b64b54a94L43-R74): Added new crushing recipes for `RAW_ZINC` and `RAW_COPPER`, including multiple output items with different probabilities.

### Modifications to World Generation Placement Logic:

* [`src/main/java/net/nuclearteam/createnuclear/infrastructure/worldgen/CNPlacedFeatures.java`](diffhunk://#diff-b1fcec879242fec367bb74391567fd139ac06f82a3109c3e9cde0a246d361d66L41-R41): Changed the height range placement from a uniform distribution to a triangular distribution for more varied terrain generation.