### PR TITLE
Add configuration classes for reactor settings and world generation

### DIFF
--- a/src/main/java/net/nuclearteam/createnuclear/CreateNuclear.java
+++ b/src/main/java/net/nuclearteam/createnuclear/CreateNuclear.java
@@ -23,6 +23,7 @@ import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.RegisterEvent;
 import net.nuclearteam.createnuclear.content.kinetics.fan.processing.CNFanProcessingTypes;
+import net.nuclearteam.createnuclear.infrastructure.config.CNConfigs;
 import net.nuclearteam.createnuclear.infrastructure.data.CreateNuclearDatagen;
 import org.slf4j.Logger;
 
@@ -62,6 +63,8 @@ public class CreateNuclear {
         CNMenus.register();
         CNFluids.register();
         CNEntityType.register();
+
+        CNConfigs.register(modLoadingContext);
 
         CNCreativeModeTabs.register(modEventBus);
         CNEffects.register(modEventBus);

--- a/src/main/java/net/nuclearteam/createnuclear/infrastructure/config/CExplose.java
+++ b/src/main/java/net/nuclearteam/createnuclear/infrastructure/config/CExplose.java
@@ -1,0 +1,20 @@
+package net.nuclearteam.createnuclear.infrastructure.config;
+
+import net.createmod.catnip.config.ConfigBase;
+
+public class CExplose extends ConfigBase {
+    public final ConfigInt size = i(10, "Size of the reactor explosion");
+    public final ConfigInt type = i(1, 0, 2, "Type of explosion", Comments.type);
+    public final ConfigInt time = i(600, 100, 1200, "Duration before exploration", Comments.explosionTime, Comments.hintExplosion);
+
+    @Override
+    public String getName() {
+        return "Explosion Reactor";
+    }
+
+    private static class Comments {
+        static String explosionTime = "Create Nuclear Explosion Time";
+        static String hintExplosion = "300 ticks = 15 seconds";
+        static String type = "Explanation: 0 = no explosion, 1 = current explosion, 2 = new explosion.";
+    }
+}

--- a/src/main/java/net/nuclearteam/createnuclear/infrastructure/config/CNCClient.java
+++ b/src/main/java/net/nuclearteam/createnuclear/infrastructure/config/CNCClient.java
@@ -1,0 +1,4 @@
+package net.nuclearteam.createnuclear.infrastructure.config;
+
+public class CNCClient {
+}

--- a/src/main/java/net/nuclearteam/createnuclear/infrastructure/config/CNCCommon.java
+++ b/src/main/java/net/nuclearteam/createnuclear/infrastructure/config/CNCCommon.java
@@ -1,0 +1,20 @@
+package net.nuclearteam.createnuclear.infrastructure.config;
+
+import net.createmod.catnip.config.ConfigBase;
+
+public class CNCCommon extends ConfigBase {
+    public final CWorldGen worldGen = nested(0, CWorldGen::new, Comments.worldGen);
+    public final CRods rods = nested(0, CRods::new, Comments.rods);
+    public final CExplose explode = nested(0, CExplose::new, Comments.explode);
+
+    @Override
+    public String getName() {
+        return "Common";
+    }
+
+    private static class Comments {
+        static String worldGen = "Modify CreateNuclear's impact on your terrain";
+        static String rods = "Modify rods time and config";
+        static String explode = "Explose: pas d'idée";
+    }
+}

--- a/src/main/java/net/nuclearteam/createnuclear/infrastructure/config/CNCServer.java
+++ b/src/main/java/net/nuclearteam/createnuclear/infrastructure/config/CNCServer.java
@@ -1,0 +1,4 @@
+package net.nuclearteam.createnuclear.infrastructure.config;
+
+public class CNCServer {
+}

--- a/src/main/java/net/nuclearteam/createnuclear/infrastructure/config/CNConfigs.java
+++ b/src/main/java/net/nuclearteam/createnuclear/infrastructure/config/CNConfigs.java
@@ -1,0 +1,72 @@
+package net.nuclearteam.createnuclear.infrastructure.config;
+
+import net.createmod.catnip.config.ConfigBase;
+import net.minecraftforge.common.ForgeConfigSpec;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.ModLoadingContext;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
+import net.minecraftforge.fml.config.ModConfig;
+
+import net.minecraftforge.fml.event.config.ModConfigEvent;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Supplier;
+
+@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
+public class CNConfigs {
+    private static final Map<ModConfig.Type, ConfigBase> CONFIGS = new EnumMap<>(ModConfig.Type.class);
+
+    private static CNCClient client;
+    private static CNCCommon common;
+    private static CNCServer server;
+
+    public static CNCCommon common() {
+        return common;
+    }
+
+    public static ConfigBase byType(ModConfig.Type type) {
+        return CONFIGS.get(type);
+    }
+
+    private static <T extends ConfigBase> T register(Supplier<T> factory, ModConfig.Type side) {
+        Pair<T, ForgeConfigSpec> specPair = new ForgeConfigSpec.Builder().configure(builder -> {
+            T config = factory.get();
+            config.registerAll(builder);
+            return config;
+        });
+
+        T config = specPair.getLeft();
+        config.specification = specPair.getRight();
+        CONFIGS.put(side, config);
+        return config;
+    }
+
+    public static void register(ModLoadingContext context) {
+        common = register(CNCCommon::new, ModConfig.Type.COMMON);
+
+        for (Entry<ModConfig.Type, ConfigBase> entry : CONFIGS.entrySet()) {
+            context.registerConfig(entry.getKey(), entry.getValue().specification);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onLoad(ModConfigEvent.Loading event) {
+        for (ConfigBase config : CONFIGS.values()) {
+            if (config.specification == event.getConfig().getSpec()) {
+                config.onLoad();
+            }
+        }
+    }
+
+    @SubscribeEvent
+    public static void onReload(ModConfigEvent.Reloading event) {
+        for (ConfigBase config : CONFIGS.values()) {
+            if (config.specification == event.getConfig().getSpec()) {
+                config.onReload();
+            }
+        }
+    }
+}

--- a/src/main/java/net/nuclearteam/createnuclear/infrastructure/config/CRods.java
+++ b/src/main/java/net/nuclearteam/createnuclear/infrastructure/config/CRods.java
@@ -1,0 +1,22 @@
+package net.nuclearteam.createnuclear.infrastructure.config;
+
+import net.createmod.catnip.config.ConfigBase;
+
+public class CRods extends ConfigBase {
+    public final ConfigInt uraniumRodLifetime = i(3600, 100, 5000, "Uranium rod lifespan", Comments.UraniumRodLifetime, Comments.hintTick);
+    public final ConfigInt graphiteRodLifetime = i(3600, 100, 5000, "Graphite rod lifespan", Comments.GraphiteRodLifetime, Comments.hintTick);
+    public final ConfigInt maxHeat = i(1000, 200, 1000, "Maximum reactor heat", Comments.maxHeat, Comments.hintHeat);
+
+    @Override
+    public String getName() {
+        return "Rods";
+    }
+
+    private static class Comments {
+        static String hintTick = "20 ticks = 1 second";
+        static String UraniumRodLifetime = "Uranium rod lifespan in reactor";
+        static String GraphiteRodLifetime = "Graphite rod lifespan in reactor";
+        static String maxHeat = "Maximum heat a reactor block can handle";
+        static String hintHeat = "Avoids reactor failure due to excessive heat";
+    }
+}

--- a/src/main/java/net/nuclearteam/createnuclear/infrastructure/config/CWorldGen.java
+++ b/src/main/java/net/nuclearteam/createnuclear/infrastructure/config/CWorldGen.java
@@ -1,0 +1,16 @@
+package net.nuclearteam.createnuclear.infrastructure.config;
+
+import net.createmod.catnip.config.ConfigBase;
+
+public class CWorldGen extends ConfigBase {
+    public final ConfigBool disable = b(false, "disableWorldGen", Comments.disable);
+
+    @Override
+    public String getName() {
+        return "worldGen";
+    }
+
+    private static class Comments {
+        static String disable = "Prevents all worldgen added by Create from taking effect";
+    }
+}


### PR DESCRIPTION
This pull request introduces a new configuration system for the Create Nuclear mod, adding several configuration classes and ensuring they are registered properly. The changes include the addition of new configuration files, modifications to the main initialization method, and the setup of configuration registration.

### Configuration System Enhancements:

* Added `CNConfigs` class to manage and register configuration files, including event handling for loading and reloading configurations.
* Created `CNCCommon` class to define common configuration settings, including nested configurations for world generation, rods, and explosions.
* Introduced `CExplose` class to manage explosion-related settings, including size, type, and duration of reactor explosions.
* Added `CRods` class to configure rod-related settings, such as uranium and graphite rod lifespans and maximum reactor heat.
* Implemented `CWorldGen` class to control world generation settings, with an option to disable world generation.

### Main Initialization Changes:

* Updated `CreateNuclear.java` to import `CNConfigs` and register configurations during the mod initialization process. [[1]](diffhunk://#diff-5689a00dee3e53890a1835edd63a7f0461f4e985a151650e39ec9c25f24599e1R26) [[2]](diffhunk://#diff-5689a00dee3e53890a1835edd63a7f0461f4e985a151650e39ec9c25f24599e1R67-R68)