### PR TITLE
debug radiation effect was not in creative

### DIFF
--- a/src/main/java/net/nuclearteam/createnuclear/CNFluids.java
+++ b/src/main/java/net/nuclearteam/createnuclear/CNFluids.java
@@ -52,7 +52,7 @@ public class CNFluids {
 
     public static void handleFluidEffect(LivingEvent.LivingTickEvent event) {
         LivingEntity entity = event.getEntity();
-        if (entity.isAlive() && !(entity.isSpectator() || entity instanceof Player player && player.isCreative())) {
+        if (entity.isAlive() && !(entity.isSpectator())) {
             if (entity.tickCount % 20 == 0) return;
             if (entity.isInFluidType(URANIUM.getType())) {
                 entity.addEffect(new MobEffectInstance(CNEffects.RADIATION.get(), 100, 0));

--- a/src/main/java/net/nuclearteam/createnuclear/foundation/mixin/BaseFireBlockMixin.java
+++ b/src/main/java/net/nuclearteam/createnuclear/foundation/mixin/BaseFireBlockMixin.java
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(BaseFireBlock.class)
 public abstract class BaseFireBlockMixin {
-    @Inject(at = @At("HEAD"), method = "m_49245_", cancellable = true)
+    @Inject(at = @At("HEAD"), method = "getState", cancellable = true)
     private static void CN$getState(BlockGetter reader, BlockPos pos, CallbackInfoReturnable<BlockState> cir) {
         BlockPos blockPos = pos.below();
         BlockState blockState = reader.getBlockState(blockPos);


### PR DESCRIPTION
This pull request includes changes to the `src/main/java/net/nuclearteam/createnuclear` directory to improve fluid handling and fire block state retrieval. The most important changes include modifying the conditions for applying fluid effects to entities and updating the method name in a mixin class.

Improvements to fluid handling:

* [`src/main/java/net/nuclearteam/createnuclear/CNFluids.java`](diffhunk://#diff-93d938e5eb8bced352d7ebf8b23735657e0db365197fc562c336251f24fbba4fL55-R55): Modified the condition to apply fluid effects to entities by removing the check for creative mode players.

Updates to fire block state retrieval:

* [`src/main/java/net/nuclearteam/createnuclear/foundation/mixin/BaseFireBlockMixin.java`](diffhunk://#diff-3ab59d04294cbe3971a89c571771ad3b17346d1eaa65b4f699c85745bad15553L16-R16): Updated the method name from `m_49245_` to `getState` in the mixin class to improve readability and maintainability.