### PR TITLE
Fluid interaction wip

### DIFF
--- a/src/main/java/net/nuclearteam/createnuclear/CNFluids.java
+++ b/src/main/java/net/nuclearteam/createnuclear/CNFluids.java
@@ -12,9 +12,13 @@ import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.material.FluidState;
+import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.common.SoundActions;
 import net.minecraftforge.event.entity.living.LivingEvent;
+import net.minecraftforge.fluids.FluidInteractionRegistry;
+import net.minecraftforge.fluids.FluidInteractionRegistry.InteractionInformation;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.ForgeFlowingFluid;
 import org.joml.Vector3f;
@@ -59,6 +63,29 @@ public class CNFluids {
             }
         }
 
+    }
+
+    public static void registerFluidInteractions() {
+        FluidInteractionRegistry.addInteraction(ForgeMod.LAVA_TYPE.get(), new InteractionInformation(
+            URANIUM.get().getFluidType(),
+            (fluidState) -> {
+                if (fluidState.isSource()) {
+                    return Blocks.BLACKSTONE.defaultBlockState();
+                } else {
+                    return Blocks.LIGHT_GRAY_SHULKER_BOX.defaultBlockState();
+                }
+            }
+        ));
+        FluidInteractionRegistry.addInteraction(ForgeMod.WATER_TYPE.get(), new InteractionInformation(
+                URANIUM.get().getFluidType(),
+                fluidState -> {
+                    if (fluidState.isSource()) {
+                        return Blocks.ACACIA_LOG.defaultBlockState();
+                    } else {
+                        return Blocks.BEACON.defaultBlockState();
+                    }
+                }
+        ));
     }
 
     private static class SolidRenderedPlaceableFluidtype extends AllFluids.TintedFluidType {

--- a/src/main/java/net/nuclearteam/createnuclear/CreateNuclear.java
+++ b/src/main/java/net/nuclearteam/createnuclear/CreateNuclear.java
@@ -81,6 +81,7 @@ public class CreateNuclear {
     }
 
     public static void init(final FMLCommonSetupEvent event) {
+        CNFluids.registerFluidInteractions();
         event.enqueueWork(CNPotions::registerPotionsRecipes);
     }
 


### PR DESCRIPTION
This pull request introduces new fluid interaction mechanics, updates the handling of fluid effects, and includes a minor fix in a mixin method. The most significant changes are the addition of fluid interaction logic and the removal of a condition for creative players in fluid effect handling.

### Fluid interaction mechanics:

* [`src/main/java/net/nuclearteam/createnuclear/CNFluids.java`](diffhunk://#diff-93d938e5eb8bced352d7ebf8b23735657e0db365197fc562c336251f24fbba4fR68-R90): Added the `registerFluidInteractions` method to define interactions between uranium fluid and both lava and water. These interactions result in specific block transformations, such as lava turning uranium fluid into blackstone or light gray shulker boxes, and water turning uranium fluid into acacia logs or beacons depending on the fluid state.

* [`src/main/java/net/nuclearteam/createnuclear/CreateNuclear.java`](diffhunk://#diff-5689a00dee3e53890a1835edd63a7f0461f4e985a151650e39ec9c25f24599e1R84): Updated the `init` method to call `CNFluids.registerFluidInteractions` during initialization.

### Fluid effect handling:

* [`src/main/java/net/nuclearteam/createnuclear/CNFluids.java`](diffhunk://#diff-93d938e5eb8bced352d7ebf8b23735657e0db365197fc562c336251f24fbba4fL55-R59): Modified the `handleFluidEffect` method to remove the condition that exempted creative players from radiation effects when in uranium fluid.

### Mixin method fix:

* [`src/main/java/net/nuclearteam/createnuclear/foundation/mixin/BaseFireBlockMixin.java`](diffhunk://#diff-3ab59d04294cbe3971a89c571771ad3b17346d1eaa65b4f699c85745bad15553L16-R16): Corrected the method name in the `@Inject` annotation from `m_49245_` to `getState` for better clarity and maintainability.