### PR TITLE
Fix mixin

### DIFF
--- a/src/main/java/net/nuclearteam/createnuclear/foundation/mixin/BaseFireBlockMixin.java
+++ b/src/main/java/net/nuclearteam/createnuclear/foundation/mixin/BaseFireBlockMixin.java
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(BaseFireBlock.class)
 public abstract class BaseFireBlockMixin {
-    @Inject(at = @At("HEAD"), method = "getState", cancellable = true)
+    @Inject(at = @At("HEAD"), method = "m_49245_", cancellable = true)
     private static void CN$getState(BlockGetter reader, BlockPos pos, CallbackInfoReturnable<BlockState> cir) {
         BlockPos blockPos = pos.below();
         BlockState blockState = reader.getBlockState(blockPos);


### PR DESCRIPTION
This pull request updates the `BaseFireBlockMixin` class to reflect changes in method naming conventions following the latest Minecraft mappings.

* [`src/main/java/net/nuclearteam/createnuclear/foundation/mixin/BaseFireBlockMixin.java`](diffhunk://#diff-3ab59d04294cbe3971a89c571771ad3b17346d1eaa65b4f699c85745bad15553L16-R16): Renamed the method `getState` to `m_49245_` to align with updated Minecraft method mappings.