### PR TITLE
Refactor item validation in ReactorInputInventory to use CNTags for better maintainability

### DIFF
--- a/src/main/java/net/nuclearteam/createnuclear/content/multiblock/controller/ReactorControllerBlockEntity.java
+++ b/src/main/java/net/nuclearteam/createnuclear/content/multiblock/controller/ReactorControllerBlockEntity.java
@@ -21,10 +21,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
-import net.nuclearteam.createnuclear.CNBlocks;
-import net.nuclearteam.createnuclear.CNItems;
-import net.nuclearteam.createnuclear.CNPackets;
-import net.nuclearteam.createnuclear.CreateNuclear;
+import net.nuclearteam.createnuclear.*;
 import net.nuclearteam.createnuclear.content.multiblock.IHeat;
 import net.nuclearteam.createnuclear.content.multiblock.input.ReactorInputEntity;
 import net.nuclearteam.createnuclear.content.multiblock.output.ReactorOutput;
@@ -319,10 +316,10 @@ public class ReactorControllerBlockEntity extends SmartBlockEntity implements II
         String currentRod = "";
         ListTag list = inventory.getStackInSlot(0).getOrCreateTag().getCompound("pattern").getList("Items", Tag.TAG_COMPOUND);
         for (int i = 0; i < list.size(); i++) {
-            if (list.getCompound(i).getString("id").equals("createnuclear:uranium_rod")) {
+            if (ItemStack.of(list.getCompound(i)).is(CNTags.CNItemTags.FUEL.tag)) {
                 heat += baseUraniumHeat;
                 currentRod = "u";
-            } else if (list.getCompound(i).getString("id").equals("createnuclear:graphite_rod")) {
+            } else if (ItemStack.of(list.getCompound(i)).is(CNTags.CNItemTags.COOLER.tag)) {
                 heat += baseGraphiteHeat;
                 currentRod = "g";
             }
@@ -350,10 +347,10 @@ public class ReactorControllerBlockEntity extends SmartBlockEntity implements II
                             if (list.getCompound(l).getInt("Slot") == neighborSlot) {
                                 // If the currentRod equals "u", apply the corresponding heat
                                 if (currentRod.equals("u")) {
-                                    String id = list.getCompound(l).getString("id");
-                                    if (id.equals("createnuclear:uranium_rod")) {
+                                    ItemStack stack = ItemStack.of(list.getCompound(i));
+                                    if (stack.is(CNTags.CNItemTags.FUEL.tag)) {
                                         heat += proximityUraniumHeat;
-                                    } else if (id.equals("createnuclear:graphite_rod")) {
+                                    } else if (stack.is(CNTags.CNItemTags.COOLER.tag)) {
                                         heat += proximityGraphiteHeat;
                                     }
                                 }

--- a/src/main/java/net/nuclearteam/createnuclear/content/multiblock/input/ReactorInputInventory.java
+++ b/src/main/java/net/nuclearteam/createnuclear/content/multiblock/input/ReactorInputInventory.java
@@ -4,6 +4,7 @@ package net.nuclearteam.createnuclear.content.multiblock.input;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.items.ItemStackHandler;
 import net.nuclearteam.createnuclear.CNItems;
+import net.nuclearteam.createnuclear.CNTags;
 import org.jetbrains.annotations.NotNull;
 
 public class ReactorInputInventory extends ItemStackHandler {
@@ -23,8 +24,8 @@ public class ReactorInputInventory extends ItemStackHandler {
     @Override
     public boolean isItemValid(int slot, @NotNull ItemStack stack) {
         return switch (slot) {
-            case 0 -> CNItems.URANIUM_ROD.get() == stack.getItem();
-            case 1 -> CNItems.GRAPHITE_ROD.get() == stack.getItem();
+            case 0 -> CNTags.CNItemTags.FUEL.matches(stack);
+            case 1 -> CNTags.CNItemTags.COOLER.matches(stack);
             default -> !super.isItemValid(slot, stack);
         };
     }


### PR DESCRIPTION
This pull request refactors the codebase to replace hardcoded item checks with tag-based checks, improving flexibility and maintainability. Additionally, wildcard imports were introduced in one file. The most important changes are summarized below:

### Refactoring to use tag-based item checks:
* Updated `calculateHeat` in `ReactorControllerBlockEntity` to replace hardcoded item ID checks (`"createnuclear:uranium_rod"` and `"createnuclear:graphite_rod"`) with checks using `CNTags.CNItemTags.FUEL.tag` and `CNTags.CNItemTags.COOLER.tag`. This change applies to both the main loop and proximity heat calculations. [[1]](diffhunk://#diff-6265a865e5faf41e08caf8b770b94fd4822a474b707ba388cece559a78fc2454L322-R322) [[2]](diffhunk://#diff-6265a865e5faf41e08caf8b770b94fd4822a474b707ba388cece559a78fc2454L353-R353)
* Modified `isItemValid` in `ReactorInputInventory` to use `CNTags.CNItemTags.FUEL.matches` and `CNTags.CNItemTags.COOLER.matches` instead of directly comparing items to `CNItems.URANIUM_ROD` and `CNItems.GRAPHITE_ROD`.

### Import changes:
* Replaced specific imports with a wildcard import (`import net.nuclearteam.createnuclear.*`) in `ReactorControllerBlockEntity`. This reduces verbosity but may introduce unnecessary imports.
* Added the `CNTags` import in `ReactorInputInventory` to support the tag-based checks.