### PR TITLE
Add CNAttributes class to register custom attributes for irradiated r…

### DIFF
--- a/src/generated/resources/.cache/3c9854c256b4d84dd9b4b92d1a03ceb45298124f
+++ b/src/generated/resources/.cache/3c9854c256b4d84dd9b4b92d1a03ceb45298124f
@@ -1,4 +1,4 @@
-// 1.20.1	2025-11-11T13:56:47.9632247	Registrate Provider for createnuclear [Recipes, Advancements, Loot Tables, Tags (blocks), Tags (items), Tags (fluids), Tags (entity_types), Blockstates, Item models, Lang (en_us/en_ud)]
+// 1.20.1	2025-11-15T19:18:55.633233	Registrate Provider for createnuclear [Recipes, Advancements, Loot Tables, Tags (blocks), Tags (items), Tags (fluids), Tags (entity_types), Blockstates, Item models, Lang (en_us/en_ud)]
 0b2c76c9cff305eacfdfb57c4b703f94ca6dc903 assets/createnuclear/blockstates/autunite.json
 5d06bc544bcbeb7443178d66955bb5101cf696da assets/createnuclear/blockstates/autunite_pillar.json
 5b375444ac5057e63776f4991589c57824574b4a assets/createnuclear/blockstates/cut_autunite.json
@@ -38,8 +38,8 @@ a2fc21fa320e677fe7690b260ee3f57ebdbd50b6 assets/createnuclear/blockstates/small_
 57c846a957e9250bc45f2f1091bf3f78b2a77344 assets/createnuclear/blockstates/steel_block.json
 de2884054a21315d8b167f64b206be331d388420 assets/createnuclear/blockstates/uranium.json
 4557f548df100ae1d05e3b5711797225f6a39673 assets/createnuclear/blockstates/uranium_ore.json
-27f15cf0f283a9dbd23b2af0069bffb349080a57 assets/createnuclear/lang/en_ud.json
-2e3ff05dfc61519481e228d1b85e1c3e5e4ad55c assets/createnuclear/lang/en_us.json
+339779f576dd991689b931a73bfb9e34340ad640 assets/createnuclear/lang/en_ud.json
+e703f95d56cd745b493cc66cb5591b86d74aacf6 assets/createnuclear/lang/en_us.json
 a8495d2cd5e38213683becaf1c84b2852f8b06f5 assets/createnuclear/models/block/autunite_natural_0.json
 29394a22ee8655dc22ea51563411505fbcfd2dab assets/createnuclear/models/block/autunite_natural_1.json
 9e4f83de1ca7a9ab5363f43fc7c3f7f4ec6164d5 assets/createnuclear/models/block/autunite_natural_2.json

--- a/src/generated/resources/assets/createnuclear/lang/en_ud.json
+++ b/src/generated/resources/assets/createnuclear/lang/en_ud.json
@@ -51,6 +51,7 @@
   "advancement.createnuclear.uranium_rod.desc": "ɹǝʇɟɐɹɔ ןɐɔıuɐɥɔǝɯ ɐ uı ǝʞɐɔʍoןןǝʎ pǝɥɔıɹuǝ buısn poɹ ɯnıuɐɹn ʇsɹıɟ ɹnoʎ ǝʇɐǝɹƆ",
   "advancement.createnuclear.yellowcake": "ssǝɔoɹԀ ǝʞɐɔʍoןןǝʎ ǝɥ⟘",
   "advancement.createnuclear.yellowcake.desc": "ǝʞɐɔʍoןןǝʎ ǝʇɐǝɹɔ oʇ pınbıן ɯnıuɐɹn ʇɔɐdɯoƆ",
+  "attribute.name.createnuclear.generic.irradiated_resistance": "ǝɔuɐʇsısǝᴚ uoıʇɐıpɐᴚ",
   "block.createnuclear.autunite": "ǝʇıunʇnⱯ",
   "block.createnuclear.autunite_pillar": "ɹɐןןıԀ ǝʇıunʇnⱯ",
   "block.createnuclear.cut_autunite": "ǝʇıunʇnⱯ ʇnƆ",

--- a/src/generated/resources/assets/createnuclear/lang/en_us.json
+++ b/src/generated/resources/assets/createnuclear/lang/en_us.json
@@ -51,6 +51,7 @@
   "advancement.createnuclear.uranium_rod.desc": "Create your first uranium rod using enriched yellowcake in a mechanical crafter",
   "advancement.createnuclear.yellowcake": "The Yellowcake Process",
   "advancement.createnuclear.yellowcake.desc": "Compact uranium liquid to create yellowcake",
+  "attribute.name.createnuclear.generic.irradiated_resistance": "Radiation Resistance",
   "block.createnuclear.autunite": "Autunite",
   "block.createnuclear.autunite_pillar": "Autunite Pillar",
   "block.createnuclear.cut_autunite": "Cut Autunite",

--- a/src/main/java/net/nuclearteam/createnuclear/CNAttributes.java
+++ b/src/main/java/net/nuclearteam/createnuclear/CNAttributes.java
@@ -1,0 +1,18 @@
+package net.nuclearteam.createnuclear;
+
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.RangedAttribute;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+public class CNAttributes {
+    public static final DeferredRegister<Attribute> ATTRIBUTES = DeferredRegister.create(ForgeRegistries.ATTRIBUTES, CreateNuclear.MOD_ID);
+
+    public static final RegistryObject<Attribute> IRRADIATED_RESISTANCE = ATTRIBUTES.register("generic.irradiated_resistance", () -> new RangedAttribute("attribute.name.createnuclear.generic.irradiated_resistance", 0, 0, 6));
+
+    public static void register(IEventBus eventBus) {
+        ATTRIBUTES.register(eventBus);
+    }
+}

--- a/src/main/java/net/nuclearteam/createnuclear/CreateNuclear.java
+++ b/src/main/java/net/nuclearteam/createnuclear/CreateNuclear.java
@@ -71,6 +71,7 @@ public class CreateNuclear {
         CNEffects.register(modEventBus);
         CNPotions.register(modEventBus);
         CNRecipeTypes.register(modEventBus);
+        CNAttributes.register(modEventBus);
 
         modEventBus.addListener(CreateNuclear::init);
         modEventBus.addListener(CreateNuclear::onRegister);

--- a/src/main/java/net/nuclearteam/createnuclear/content/equipment/armor/AntiRadiationArmorItem.java
+++ b/src/main/java/net/nuclearteam/createnuclear/content/equipment/armor/AntiRadiationArmorItem.java
@@ -1,10 +1,17 @@
 package net.nuclearteam.createnuclear.content.equipment.armor;
 
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
 import com.tterrag.registrate.util.entry.ItemEntry;
+import net.minecraft.Util;
+import net.minecraft.network.chat.Component;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.item.*;
+import net.nuclearteam.createnuclear.CNAttributes;
 import net.nuclearteam.createnuclear.CNItems;
 import net.nuclearteam.createnuclear.CNTags.CNItemTags;
 import net.nuclearteam.createnuclear.CreateNuclear;
@@ -21,12 +28,25 @@ public class AntiRadiationArmorItem {
     public static final ArmorItem.Type BOOTS = ArmorItem.Type.BOOTS;
     public static final ArmorMaterial ARMOR_MATERIAL = ArmorMaterials.ANTI_RADIATION_SUIT;
 
+    private static final EnumMap<ArmorItem.Type, UUID> ARMOR_MODIFIER_UUID_PER_TYPE = Util.make(new EnumMap<>(ArmorItem.Type.class), (p_266744_) -> {
+        p_266744_.put(ArmorItem.Type.BOOTS, UUID.fromString("845DB27C-C624-495F-8C9F-6020A9A58B6B"));
+        p_266744_.put(ArmorItem.Type.LEGGINGS, UUID.fromString("D8499B04-0E66-4726-AB29-64469D734E0D"));
+        p_266744_.put(ArmorItem.Type.CHESTPLATE, UUID.fromString("9F3D476D-C118-4544-8365-64846904B48E"));
+        p_266744_.put(ArmorItem.Type.HELMET, UUID.fromString("2AD3F246-FEE1-4E67-B886-69FD380BB150"));
+    });
 
     public static class Helmet extends ArmorItem {
         protected final DyeColor color;
+
+        private final Multimap<Attribute, AttributeModifier> attributeModifiers;
+
         public Helmet(Properties properties, DyeColor color) {
             super(ARMOR_MATERIAL, HELMET, properties);
             this.color = color;
+            ImmutableMultimap.Builder<Attribute, AttributeModifier> builder = ImmutableMultimap.builder();
+            UUID uuid = ARMOR_MODIFIER_UUID_PER_TYPE.get(HELMET);
+            builder.put(CNAttributes.IRRADIATED_RESISTANCE.get(), new AttributeModifier(uuid, "Armor Resistance Irradiation", 42, AttributeModifier.Operation.ADDITION));
+            this.attributeModifiers = builder.build();
         }
 
         @Override
@@ -87,7 +107,10 @@ public class AntiRadiationArmorItem {
                     : CNItemTags.ANTI_RADIATION_HELMET_DYE.tag;
         }
 
-
+        @Override
+        public Multimap<Attribute, AttributeModifier> getDefaultAttributeModifiers(EquipmentSlot pEquipmentSlot) {
+            return pEquipmentSlot == this.type.getSlot() ? this.attributeModifiers : super.getDefaultAttributeModifiers(pEquipmentSlot);
+        }
     }
 
     public static class Chestplate extends ArmorItem {

--- a/src/main/java/net/nuclearteam/createnuclear/foundation/mixin/BaseFireBlockMixin.java
+++ b/src/main/java/net/nuclearteam/createnuclear/foundation/mixin/BaseFireBlockMixin.java
@@ -13,8 +13,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(BaseFireBlock.class)
 public abstract class BaseFireBlockMixin {
-    //    @Inject(at = @At("HEAD"), method = "getState", cancellable = true)
-    @Inject(at = @At("HEAD"), method = "m_49245_", cancellable = true)
+        @Inject(at = @At("HEAD"), method = "getState", cancellable = true)
+//    @Inject(at = @At("HEAD"), method = "m_49245_", cancellable = true)
     private static void CN$getState(BlockGetter reader, BlockPos pos, CallbackInfoReturnable<BlockState> cir) {
         BlockPos blockPos = pos.below();
         BlockState blockState = reader.getBlockState(blockPos);

--- a/src/main/resources/assets/createnuclear/lang/default/tooltips.json
+++ b/src/main/resources/assets/createnuclear/lang/default/tooltips.json
@@ -59,5 +59,7 @@
   "tag.item.trinkets.head.face": "Head Face",
 
 
-  "overlay.event_message": "⚠ Warning ⚠ %s timer"
+  "overlay.event_message": "⚠ Warning ⚠ %s timer",
+
+  "attribute.name.createnuclear.generic.irradiated_resistance": "Radiation Resistance"
 }


### PR DESCRIPTION

This pull request introduces a new custom attribute, "Irradiated Resistance," to the mod, integrates it into the anti-radiation helmet item, and makes supporting changes for registration and localization. Additionally, it fixes a mixin annotation for fire block behavior.

**New Attribute System and Item Integration:**

* Added a new class `CNAttributes` that defines and registers the custom attribute `IRRADIATED_RESISTANCE` for radiation resistance, and hooked it into the mod's event bus for proper registration (`CNAttributes.java`, `CreateNuclear.java`). [[1]](diffhunk://#diff-c4677103a91c3b80bf92adf120ef94ba34aa2f81542f3fbbecf89eec6c4a4ddeR1-R18) [[2]](diffhunk://#diff-5689a00dee3e53890a1835edd63a7f0461f4e985a151650e39ec9c25f24599e1R74)
* Integrated the new `IRRADIATED_RESISTANCE` attribute into the anti-radiation helmet by assigning a unique attribute modifier that grants radiation resistance when equipped (`AntiRadiationArmorItem.java`). [[1]](diffhunk://#diff-d4f1ab6f383e623f74920bb1014f6fbc7308348868a72f878f48dc5a541531ffR3-R14) [[2]](diffhunk://#diff-d4f1ab6f383e623f74920bb1014f6fbc7308348868a72f878f48dc5a541531ffR31-R49) [[3]](diffhunk://#diff-d4f1ab6f383e623f74920bb1014f6fbc7308348868a72f878f48dc5a541531ffL90-R113)

**Localization:**

* Added a localization entry for the new attribute's display name ("Radiation Resistance") in the tooltips JSON (`tooltips.json`).

**Technical/Maintenance:**

* Fixed the mixin annotation in `BaseFireBlockMixin` to use the correct method name (`getState`) for compatibility and clarity (`BaseFireBlockMixin.java`).