### PR TITLE
Use configuration for graphite and uranium rod lifetimes in ReactorControllerBlockEntity

### DIFF
--- a/src/main/java/net/nuclearteam/createnuclear/content/multiblock/controller/ReactorControllerBlockEntity.java
+++ b/src/main/java/net/nuclearteam/createnuclear/content/multiblock/controller/ReactorControllerBlockEntity.java
@@ -26,6 +26,7 @@ import net.nuclearteam.createnuclear.content.multiblock.IHeat;
 import net.nuclearteam.createnuclear.content.multiblock.input.ReactorInputEntity;
 import net.nuclearteam.createnuclear.content.multiblock.output.ReactorOutput;
 import net.nuclearteam.createnuclear.content.multiblock.output.ReactorOutputEntity;
+import net.nuclearteam.createnuclear.infrastructure.config.CNConfigs;
 
 import java.util.List;
 
@@ -59,8 +60,8 @@ public class ReactorControllerBlockEntity extends SmartBlockEntity implements II
     public int proximityUraniumHeat = 5;
     public int proximityGraphiteHeat = -5;
     public int maxUraniumPerGraphite = 3;
-    public int graphiteTimer = 3600;
-    public int uraniumTimer = 3600;
+    public int graphiteTimer = CNConfigs.common().rods.graphiteRodLifetime.get();
+    public int uraniumTimer = CNConfigs.common().rods.uraniumRodLifetime.get();
     public int countUraniumRod;
     public int countGraphiteRod;
     public int heat;
@@ -142,7 +143,6 @@ public class ReactorControllerBlockEntity extends SmartBlockEntity implements II
         if (ItemStack.of(compound.getCompound("cooler")) != null || ItemStack.of(compound.getCompound("fuel")) != null) {
             coolerItem = ItemStack.of(compound.getCompound("cooler"));
             fuelItem = ItemStack.of(compound.getCompound("fuel"));
-
         }
         /*
         countGraphiteRod = compound.getInt("countGraphiteRod");


### PR DESCRIPTION
This pull request updates the initialization of rod lifetime timers in the `ReactorControllerBlockEntity` to use configurable values from `CNConfigs` instead of hardcoded constants. This change makes the rod lifetimes adjustable via configuration, improving flexibility for users and maintainers.

Configuration improvements:
* Updated `graphiteTimer` and `uraniumTimer` initialization in `ReactorControllerBlockEntity` to use values from `CNConfigs.common().rods.graphiteRodLifetime` and `CNConfigs.common().rods.uraniumRodLifetime` respectively, instead of hardcoded values.
* Added import for `CNConfigs` in `ReactorControllerBlockEntity.java` to support configurable rod lifetimes.