### PR TITLE
V2 damage type

### DIFF
--- a/src/generated/resources/.cache/3c9854c256b4d84dd9b4b92d1a03ceb45298124f
+++ b/src/generated/resources/.cache/3c9854c256b4d84dd9b4b92d1a03ceb45298124f
@@ -1,4 +1,4 @@
-// 1.20.1	2025-12-30T17:59:09.0633214	Registrate Provider for createnuclear [Recipes, Advancements, Loot Tables, Tags (blocks), Tags (items), Tags (fluids), Tags (entity_types), Blockstates, Item models, Lang (en_us/en_ud)]
+// 1.20.1	2025-12-30T18:48:31.1393231	Registrate Provider for createnuclear [Recipes, Advancements, Loot Tables, Tags (blocks), Tags (items), Tags (fluids), Tags (entity_types), Blockstates, Item models, Lang (en_us/en_ud)]
 0b2c76c9cff305eacfdfb57c4b703f94ca6dc903 assets/createnuclear/blockstates/autunite.json
 5d06bc544bcbeb7443178d66955bb5101cf696da assets/createnuclear/blockstates/autunite_pillar.json
 5b375444ac5057e63776f4991589c57824574b4a assets/createnuclear/blockstates/cut_autunite.json
@@ -43,8 +43,8 @@ a2fc21fa320e677fe7690b260ee3f57ebdbd50b6 assets/createnuclear/blockstates/small_
 643a4d44b491a84d0d26e1a8944dffc40e83ce14 assets/createnuclear/blockstates/thorium_ore.json
 de2884054a21315d8b167f64b206be331d388420 assets/createnuclear/blockstates/uranium.json
 4557f548df100ae1d05e3b5711797225f6a39673 assets/createnuclear/blockstates/uranium_ore.json
-5927028d82db592d0320c6907fb86be33e9ebd0a assets/createnuclear/lang/en_ud.json
-0edd6fa0242ad60aa8c70f32353b38598cc0539b assets/createnuclear/lang/en_us.json
+0e56395147322a1940b54d0487af5fd70dea64bf assets/createnuclear/lang/en_ud.json
+8197d0d707fbf919d5d1108e53441aeffaddfedd assets/createnuclear/lang/en_us.json
 a8495d2cd5e38213683becaf1c84b2852f8b06f5 assets/createnuclear/models/block/autunite_natural_0.json
 29394a22ee8655dc22ea51563411505fbcfd2dab assets/createnuclear/models/block/autunite_natural_1.json
 9e4f83de1ca7a9ab5363f43fc7c3f7f4ec6164d5 assets/createnuclear/models/block/autunite_natural_2.json

--- a/src/generated/resources/.cache/fed443662143001aeb5341375f6f5ef31d10baea
+++ b/src/generated/resources/.cache/fed443662143001aeb5341375f6f5ef31d10baea
@@ -1,4 +1,6 @@
-// 1.20.1	2025-12-30T17:59:09.0577504	CreateNuclear Generated Registry Entries
+// 1.20.1	2025-12-30T18:48:31.1336744	CreateNuclear Generated Registry Entries
+9b26dc9810e426fa58e03de22a96f45403e5f1b3 data/createnuclear/damage_type/fan_radiation.json
+8c374052eefd34e87959a1f643e60b674f0345f8 data/createnuclear/damage_type/radiation.json
 5edbd74546f4088818e02bb7a5c5eb2ecfe25623 data/createnuclear/forge/biome_modifier/lead_ore.json
 72173023e6a31748692e750db0f5fa8c555d1009 data/createnuclear/forge/biome_modifier/striated_ores_overworld.json
 fa32145101dc12ec914684fec8c5cbb995d2c051 data/createnuclear/forge/biome_modifier/uranium_ore.json

--- a/src/generated/resources/assets/createnuclear/lang/en_ud.json
+++ b/src/generated/resources/assets/createnuclear/lang/en_ud.json
@@ -136,6 +136,8 @@
   "createnuclear.tooltip.item.graphene.rod": " :poᴚ ǝʇıɥdɐɹ⅁",
   "createnuclear.tooltip.item.unknown.rod": " :uʍouʞu∩",
   "createnuclear.tooltip.item.uranium.rod": " :poᴚ ɯnıuɐɹ∩",
+  "death.attack.createnuclear.fan_radiation": "ʇsɐןq uoıʇɐıpɐɹ ɯoɹɟ pǝıp %1$s",
+  "death.attack.createnuclear.radiation": "uoıʇɐıpɐɹ ɯoɹɟ pǝıp %1$s",
   "effect.createnuclear.radiation": "uoıʇɐıpɐᴚ",
   "emi.category.createnuclear.fan_enriched": "buıɥɔıɹuƎ ʞןnᗺ",
   "entity.createnuclear.irradiated_cat": "ʇɐƆ pǝʇɐıpɐɹɹI",

--- a/src/generated/resources/assets/createnuclear/lang/en_us.json
+++ b/src/generated/resources/assets/createnuclear/lang/en_us.json
@@ -136,6 +136,8 @@
   "createnuclear.tooltip.item.graphene.rod": "Graphite Rod: ",
   "createnuclear.tooltip.item.unknown.rod": "Unknown: ",
   "createnuclear.tooltip.item.uranium.rod": "Uranium Rod: ",
+  "death.attack.createnuclear.fan_radiation": "%1$s died from radiation blast",
+  "death.attack.createnuclear.radiation": "%1$s died from radiation",
   "effect.createnuclear.radiation": "Radiation",
   "emi.category.createnuclear.fan_enriched": "Bulk Enriching",
   "entity.createnuclear.irradiated_cat": "Irradiated Cat",

--- a/src/generated/resources/data/createnuclear/damage_type/fan_radiation.json
+++ b/src/generated/resources/data/createnuclear/damage_type/fan_radiation.json
@@ -1,0 +1,5 @@
+{
+  "exhaustion": 0.0,
+  "message_id": "createnuclear.fan_radiation",
+  "scaling": "when_caused_by_living_non_player"
+}

--- a/src/generated/resources/data/createnuclear/damage_type/radiation.json
+++ b/src/generated/resources/data/createnuclear/damage_type/radiation.json
@@ -1,0 +1,5 @@
+{
+  "exhaustion": 0.0,
+  "message_id": "createnuclear.radiation",
+  "scaling": "when_caused_by_living_non_player"
+}

--- a/src/main/java/net/nuclearteam/createnuclear/CNDamageTypes.java
+++ b/src/main/java/net/nuclearteam/createnuclear/CNDamageTypes.java
@@ -1,5 +1,6 @@
 package net.nuclearteam.createnuclear;
 
+import com.simibubi.create.foundation.damageTypes.DamageTypeBuilder;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.worldgen.BootstapContext;
 import net.minecraft.resources.ResourceKey;
@@ -7,11 +8,17 @@ import net.minecraft.world.damagesource.DamageType;
 
 @SuppressWarnings("unused")
 public class CNDamageTypes {
+    public static final ResourceKey<DamageType>
+        RADIATION = key("radiation"),
+        FAN_RADIATION = key("fan_radiation")
+    ;
+
     private static ResourceKey<DamageType> key(String name) {
         return ResourceKey.create(Registries.DAMAGE_TYPE, CreateNuclear.asResource(name));
     }
 
     public static void bootstrap(BootstapContext<DamageType> ctx) {
-
+        new DamageTypeBuilder(RADIATION).register(ctx);
+        new DamageTypeBuilder(FAN_RADIATION).register(ctx);
     }
 }

--- a/src/main/java/net/nuclearteam/createnuclear/CNItems.java
+++ b/src/main/java/net/nuclearteam/createnuclear/CNItems.java
@@ -46,7 +46,7 @@ public class CNItems {
                 .nutrition(20)
                 .saturationMod(0.3F)
                 .alwaysEat()
-                .effect((new MobEffectInstance(CNEffects.RADIATION.get(),600,2)) , 1.0F)
+                .effect(new MobEffectInstance(CNEffects.RADIATION.get(),600,2), 1.0F)
                 .build())
             )
             .register(),

--- a/src/main/java/net/nuclearteam/createnuclear/content/effects/RadiationEffect.java
+++ b/src/main/java/net/nuclearteam/createnuclear/content/effects/RadiationEffect.java
@@ -10,6 +10,7 @@ import net.nuclearteam.createnuclear.CNTags;
 import net.nuclearteam.createnuclear.content.equipment.armor.AntiRadiationArmorItem;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
+import net.nuclearteam.createnuclear.foundation.damageTypes.CreateNuclearDamageSources;
 
 public class RadiationEffect extends VicinityEffect {
 
@@ -69,6 +70,6 @@ public class RadiationEffect extends VicinityEffect {
 
         // Apply radiation damage (magic type), scaled by amplifier
         int damage = 1 << amplifier;
-        entity.hurt(entity.damageSources().magic(), damage);
+        entity.hurt(CreateNuclearDamageSources.radiation(entity.level()), damage);
     }
 }

--- a/src/main/java/net/nuclearteam/createnuclear/content/kinetics/fan/processing/CNFanProcessingTypes.java
+++ b/src/main/java/net/nuclearteam/createnuclear/content/kinetics/fan/processing/CNFanProcessingTypes.java
@@ -20,6 +20,7 @@ import net.minecraft.world.phys.Vec3;
 import net.nuclearteam.createnuclear.*;
 import net.nuclearteam.createnuclear.content.enriching.campfire.EnrichingCampfireBlock;
 import net.nuclearteam.createnuclear.content.kinetics.fan.processing.EnrichedRecipe.EnrichedWrapper;
+import net.nuclearteam.createnuclear.foundation.damageTypes.CreateNuclearDamageSources;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -113,7 +114,8 @@ public class CNFanProcessingTypes {
         @Override
         public void affectEntity(Entity entity, Level level) {
             if (entity instanceof LivingEntity livingEntity) {
-                livingEntity.addEffect(new MobEffectInstance(CNEffects.RADIATION.get(), 10, 0, true, true));
+                livingEntity.addEffect(new MobEffectInstance(CNEffects.RADIATION.get(), 10, -1, true, true));
+                livingEntity.hurt(CreateNuclearDamageSources.fanRadiation(level), 1);
             }
         }
     }

--- a/src/main/java/net/nuclearteam/createnuclear/foundation/damageTypes/CreateNuclearDamageSources.java
+++ b/src/main/java/net/nuclearteam/createnuclear/foundation/damageTypes/CreateNuclearDamageSources.java
@@ -1,0 +1,37 @@
+package net.nuclearteam.createnuclear.foundation.damageTypes;
+
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.damagesource.DamageType;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
+import net.nuclearteam.createnuclear.CNDamageTypes;
+
+import javax.annotation.Nullable;
+
+public class CreateNuclearDamageSources {
+    public static DamageSource radiation(Level level) {
+        return source(CNDamageTypes.RADIATION, level);
+    }
+    public static DamageSource fanRadiation(Level level) {
+        return source(CNDamageTypes.FAN_RADIATION, level);
+    }
+
+    private static DamageSource source(ResourceKey<DamageType> key, LevelReader level) {
+        Registry<DamageType> registry = level.registryAccess().registryOrThrow(Registries.DAMAGE_TYPE);
+        return new DamageSource(registry.getHolderOrThrow(key));
+    }
+
+    private static DamageSource source(ResourceKey<DamageType> key, LevelReader level, @Nullable Entity entity) {
+        Registry<DamageType> registry = level.registryAccess().registryOrThrow(Registries.DAMAGE_TYPE);
+        return new DamageSource(registry.getHolderOrThrow(key), entity);
+    }
+
+    private static DamageSource source(ResourceKey<DamageType> key, LevelReader level, @Nullable Entity causingEntity, @Nullable Entity directEntity) {
+        Registry<DamageType> registry = level.registryAccess().registryOrThrow(Registries.DAMAGE_TYPE);
+        return new DamageSource(registry.getHolderOrThrow(key), causingEntity, directEntity);
+    }
+}

--- a/src/main/resources/assets/createnuclear/lang/default/interface.json
+++ b/src/main/resources/assets/createnuclear/lang/default/interface.json
@@ -20,6 +20,8 @@
   "createnuclear.tooltip.item.uranium.rod": "Uranium Rod: ",
   "createnuclear.tooltip.item.graphene.rod": "Graphite Rod: ",
   "createnuclear.tooltip.item.unknown.rod": "Unknown: ",
-  "createnuclear.gui.reactor_controller.info_header.title": "Heat value"
+  "createnuclear.gui.reactor_controller.info_header.title": "Heat value",
 
+  "death.attack.createnuclear.radiation": "%1$s died from radiation",
+  "death.attack.createnuclear.fan_radiation": "%1$s died from radiation blast"
 }


### PR DESCRIPTION
This pull request introduces a new system for handling radiation-related damage types in the mod. It adds custom damage sources for radiation and fan-induced radiation, updates how radiation damage is applied throughout the codebase, and provides custom death messages for these new damage types.

**Damage Types and Sources**

* Introduced two new custom damage types, `RADIATION` and `FAN_RADIATION`, registered using `DamageTypeBuilder` in `CNDamageTypes.java`.
* Added a new utility class, `CreateNuclearDamageSources`, to provide static methods for creating these custom damage sources, supporting different entity contexts.

**Application of Custom Damage**

* Updated `RadiationEffect` to apply radiation damage using the new `CreateNuclearDamageSources.radiation()` method instead of the generic magic damage source.
* Modified fan processing logic to apply both a radiation effect and direct damage using `CreateNuclearDamageSources.fanRadiation()`, and adjusted the amplifier for the effect.

**User Feedback**

* Added custom death messages for the new damage types, improving player feedback when dying from radiation or fan radiation.