### PR TITLE
Add radioactive items to inventory with radiation effect

### DIFF
--- a/src/main/java/net/nuclearteam/createnuclear/CNItems.java
+++ b/src/main/java/net/nuclearteam/createnuclear/CNItems.java
@@ -20,6 +20,7 @@ import net.minecraft.world.entity.Mob;
 import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.item.Item;
 import net.minecraftforge.common.ForgeSpawnEggItem;
+import net.nuclearteam.createnuclear.content.effects.RadiationItem;
 import net.nuclearteam.createnuclear.content.equipment.cloth.ClothItem;
 import net.nuclearteam.createnuclear.content.multiblock.bluePrintItem.ReactorBluePrintItem;
 import net.nuclearteam.createnuclear.foundation.utility.TextUtils;
@@ -42,9 +43,9 @@ import java.util.List;
 @SuppressWarnings({"unused", "deprecation"})
 public class CNItems {
 
-    public static final ItemEntry<Item>
+    public static final ItemEntry<? extends Item>
         YELLOWCAKE = CreateNuclear.REGISTRATE
-            .item("yellowcake", Item::new)
+            .item("yellowcake", RadiationItem::new)
             .properties(p -> p.food(new FoodProperties.Builder()
                 .nutrition(20)
                 .saturationMod(0.3F)
@@ -59,7 +60,7 @@ public class CNItems {
             .register(),
 
         ENRICHED_YELLOWCAKE = CreateNuclear.REGISTRATE
-            .item("enriched_yellowcake", Item::new)
+            .item("enriched_yellowcake", RadiationItem::new)
             .register(),
 
         RAW_LEAD = CreateNuclear.REGISTRATE
@@ -73,7 +74,7 @@ public class CNItems {
             .register(),
 
         RAW_URANIUM = CreateNuclear.REGISTRATE
-            .item("raw_uranium", Item::new)
+            .item("raw_uranium", RadiationItem::new)
             .tag(CNTags.forgeItemTag("raw_ores"), CNTags.forgeItemTag("raw_materials"), CNTags.forgeItemTag("raw_materials/uranium"))
             .recipe((c, p) -> ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, c.get(), 9)
                     .unlockedBy("has_storage_blocks_raw_uranium", RegistrateRecipeProvider.has(CNTags.forgeItemTag("storage_blocks/raw_uranium")))
@@ -98,7 +99,7 @@ public class CNItems {
             .register(),
 
         URANIUM_POWDER = CreateNuclear.REGISTRATE
-            .item("uranium_powder", Item::new)
+            .item("uranium_powder", RadiationItem::new)
             .tag(CNTags.forgeItemTag("dusts"), CNTags.forgeItemTag("dusts/uranium"))
             .register(),
 
@@ -159,7 +160,7 @@ public class CNItems {
             .register(),
 
         URANIUM_ROD = CreateNuclear.REGISTRATE
-            .item("uranium_rod", Item::new)
+            .item("uranium_rod", RadiationItem::new)
             .onRegister(ItemRodTypesValue.setRodTypeInfos(new RodType.Builder()
                 .setRodConfig()
                 .fuelRodType()))

--- a/src/main/java/net/nuclearteam/createnuclear/content/effects/RadiationItem.java
+++ b/src/main/java/net/nuclearteam/createnuclear/content/effects/RadiationItem.java
@@ -1,0 +1,58 @@
+package net.nuclearteam.createnuclear.content.effects;
+
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.nuclearteam.createnuclear.CNEffects;
+
+public class RadiationItem extends Item {
+
+    public RadiationItem(Item.Properties settings) {
+        super(settings);
+    }
+
+    @Override
+    public void inventoryTick(ItemStack stack, Level world, Entity entity, int slot, boolean selected) {
+        if (world.isClientSide) return;
+
+        if (entity instanceof Player player) {
+            int total = 0;
+            for (ItemStack s : player.getInventory().items) {
+                if (s.getItem() == this) total += s.getCount();
+            }
+            for (ItemStack s : player.getInventory().offhand) {
+                if (s.getItem() == this) total += s.getCount();
+            }
+
+
+            if (total <= 0) {
+                return;
+            }
+
+            int amp;
+
+            if (total < 9) { // Voir equilibrage
+                amp = 0;
+            }
+            else if (total < 18) { // Voir equilibrage
+                amp = 1;
+            }
+            else {
+                amp = 2;
+            }
+
+            MobEffectInstance effect = new MobEffectInstance(
+                    CNEffects.RADIATION.get(),
+                    40,
+                    amp,
+                    true,
+                    true
+            );
+
+            player.addEffect(effect);
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new `RadiationItem` class and updates several uranium-related items to use this new class. The main goal is to add a gameplay effect where carrying radioactive items applies a radiation effect to players, with the effect's strength scaling based on the quantity of such items in the player's inventory.

**Key changes:**

### Feature Addition: Radiation Effect for Items

* Added a new `RadiationItem` class in `content.effects`, which extends `Item` and overrides `inventoryTick` to apply a radiation effect (`CNEffects.RADIATION`) to players carrying these items. The effect's amplifier increases with the number of radioactive items held.

### Refactoring: Use of RadiationItem

* Updated the following items in `CNItems.java` to use `RadiationItem` instead of the base `Item` class, making them apply the radiation effect:
  - `YELLOWCAKE`
  - `ENRICHED_YELLOWCAKE`
  - `RAW_URANIUM`
  - `URANIUM_POWDER`
  - `URANIUM_ROD`

### Infrastructure

* Imported the new `RadiationItem` in `CNItems.java` to support the above changes.

These changes ensure that players are affected by radiation when carrying specific uranium-related items, adding a new gameplay mechanic related to inventory management and item effects.